### PR TITLE
[Feat] 공통 응답 클래스, 전역 예외 처리 및 초기 설정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,21 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    //Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //Spring Data JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    //Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    //Mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/idus/global/config/WebConfig.java
+++ b/src/main/java/org/sopt/idus/global/config/WebConfig.java
@@ -1,0 +1,33 @@
+package org.sopt.idus.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private static final String frondEndOrigin = "https://37-collaboration-web-idus-main.vercel.app";
+
+    private static final String localAddress = "localhost";
+
+    private static final String frontEndPort = "5173";
+
+    private static final String httpPrefix = "http://";
+
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowCredentials(true)
+                .allowedHeaders("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedOrigins(frondEndOrigin,
+                        httpPrefix + localAddress + ":" + frontEndPort);
+    }
+}

--- a/src/main/java/org/sopt/idus/global/config/WebConfig.java
+++ b/src/main/java/org/sopt/idus/global/config/WebConfig.java
@@ -2,11 +2,9 @@ package org.sopt.idus.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/org/sopt/idus/global/dto/response/BaseErrorResponse.java
+++ b/src/main/java/org/sopt/idus/global/dto/response/BaseErrorResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.idus.global.dto.response;
+
+import org.sopt.idus.global.exception.errorcode.ErrorCode;
+
+
+public record BaseErrorResponse(int code, String message, String messageDetail) {
+    public static BaseErrorResponse of(int code, String message, String messageDetail) {
+        return new BaseErrorResponse(code, message, messageDetail);
+    }
+
+    public static BaseErrorResponse of(ErrorCode errorCode) {
+        return new BaseErrorResponse(errorCode.getHttpStatus(), errorCode.getMessage(), null);
+    }
+
+    public static BaseErrorResponse of(ErrorCode errorCode, String messageDetail) {
+        return new BaseErrorResponse(errorCode.getHttpStatus(), errorCode.getMessage(), messageDetail);
+    }
+
+}

--- a/src/main/java/org/sopt/idus/global/dto/response/BaseResponse.java
+++ b/src/main/java/org/sopt/idus/global/dto/response/BaseResponse.java
@@ -1,0 +1,44 @@
+package org.sopt.idus.global.dto.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BaseResponse<T> {
+
+    private final int code;
+
+    private final String message;
+
+    private final T data;
+
+    private BaseResponse(int code, T data, String message) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> BaseResponse<T> ok(T data, String message) {
+        return new BaseResponse<>(HttpStatus.OK.value(), data, message);
+    }
+    public static <T> BaseResponse<T> ok(String message){
+        return new BaseResponse<>(HttpStatus.OK.value(), null, message);
+    }
+
+    public static <T> BaseResponse<T> ok(T data){
+        return new BaseResponse<>(HttpStatus.OK.value(), data, null);
+    }
+
+    public static <T> BaseResponse<T> create(T data, String message) {
+        return new BaseResponse<>(HttpStatus.CREATED.value(), data, message);
+    }
+
+    public static <T> BaseResponse<T> create(String message) {
+        return new BaseResponse<>(HttpStatus.CREATED.value(), null, message);
+    }
+
+    public static <T> BaseResponse<T> create(T data) {
+        return new BaseResponse<>(HttpStatus.CREATED.value(), data, null);
+    }
+
+}

--- a/src/main/java/org/sopt/idus/global/exception/customexception/CustomException.java
+++ b/src/main/java/org/sopt/idus/global/exception/customexception/CustomException.java
@@ -1,0 +1,25 @@
+package org.sopt.idus.global.exception.customexception;
+
+import lombok.Getter;
+import org.sopt.idus.global.exception.errorcode.ErrorCode;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+  private final String message;
+  private final String messageDetail;
+
+  public CustomException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+    this.message = errorCode.getMessage();
+    this.messageDetail = null;
+  }
+
+  public CustomException(ErrorCode errorCode, String messageDetail) {
+    this.errorCode = errorCode;
+    this.message = errorCode.getMessage();
+    this.messageDetail = messageDetail;
+  }
+
+}

--- a/src/main/java/org/sopt/idus/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/org/sopt/idus/global/exception/errorcode/ErrorCode.java
@@ -1,0 +1,6 @@
+package org.sopt.idus.global.exception.errorcode;
+
+public interface ErrorCode {
+    int getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/org/sopt/idus/global/exception/errorcode/GlobalErrorCode.java
+++ b/src/main/java/org/sopt/idus/global/exception/errorcode/GlobalErrorCode.java
@@ -1,0 +1,36 @@
+package org.sopt.idus.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    FILE_INIT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(),"파일 초기화에 실패하였습니다."),
+    FILE_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "파일 갱신에 실패하였습니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 요청입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED.value(), "유효하지 않은 Http 메서드입니다."),
+    NOT_FOUND_PATH(NOT_FOUND.value(), "존재하지 않는 API 입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "잘못된 요청입니다."),
+    INVALID_JSON(HttpStatus.BAD_REQUEST.value(), "JSON 형식이 올바르지 않습니다."),
+    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST.value(), "필수 요청 파라미터가 누락되었습니다."),
+    TYPE_MISMATCH(HttpStatus.BAD_REQUEST.value(), "요청 파라미터 타입이 일치하지 않습니다."),
+    MISSING_PATH_VARIABLE(HttpStatus.BAD_REQUEST.value(), "경로 변수 값이 누락되었습니다.")
+    ;
+
+    private final int httpStatus;
+    private final String message;
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/idus/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/idus/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,114 @@
+package org.sopt.idus.global.exception.handler;
+
+import org.sopt.idus.global.dto.response.BaseErrorResponse;
+import org.sopt.idus.global.exception.customexception.CustomException;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.server.MethodNotAllowedException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.stream.Collectors;
+
+import static org.sopt.idus.global.exception.errorcode.GlobalErrorCode.*;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public BaseErrorResponse handleInternalServerError(Exception e) {
+        return BaseErrorResponse.of(INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public BaseErrorResponse  HandlerMethodValidationException(HandlerMethodValidationException e){
+        String message = e.getAllErrors().stream()
+                .map(MessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining());
+
+        return BaseErrorResponse.of(INVALID_REQUEST, message);
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public BaseErrorResponse handleNoHandlerFoundException(NoHandlerFoundException e) {
+        return BaseErrorResponse.of(NOT_FOUND_PATH);
+    }
+
+    @ExceptionHandler(MethodNotAllowedException.class)
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    public BaseErrorResponse handleMethodNotAllowedException(MethodNotAllowedException e) {
+        return BaseErrorResponse.of(METHOD_NOT_ALLOWED);
+    }
+
+    //커스텀 예외
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<BaseErrorResponse> handleCustomException(CustomException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(BaseErrorResponse.of(
+                        e.getErrorCode(),
+                        e.getMessageDetail()));
+    }
+
+    //입력값 검증할 때 발생하는 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public BaseErrorResponse handleValidationExceptions(MethodArgumentNotValidException ex) {
+
+        String message = ex.getBindingResult().getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElseGet(() -> ex.getBindingResult().getGlobalErrors()
+                        .stream()
+                        .findFirst()
+                        .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                        .orElse("입력값이 잘못되었습니다.")
+                );
+
+        return BaseErrorResponse.of(HttpStatus.BAD_REQUEST.value(), message, null);
+    }
+
+    // JSON 파싱 오류
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public BaseErrorResponse handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        return BaseErrorResponse.of(INVALID_JSON);
+    }
+
+    // 요청 파라미터 누락
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public BaseErrorResponse handleMissingServletRequestParameter(MissingServletRequestParameterException e) {
+        return BaseErrorResponse.of(MISSING_REQUEST_PARAMETER);
+    }
+
+    // 타입 불일치
+    @ExceptionHandler(TypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public BaseErrorResponse handleTypeMismatch(TypeMismatchException e) {
+        return BaseErrorResponse.of(TYPE_MISMATCH);
+    }
+
+    // 경로 변수 누락
+    @ExceptionHandler(MissingPathVariableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public BaseErrorResponse handleMissingPathVariable(MissingPathVariableException e) {
+        return BaseErrorResponse.of(MISSING_PATH_VARIABLE);
+    }
+
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=idus

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,65 @@
+spring:
+  application:
+    name: DreamWeaver
+  profiles:
+    group:
+      local: local-db, local-port, common
+      dev : dev-db, dev-port, common
+    active: local
+
+---
+spring:
+  config:
+    activate:
+      on-profile: common
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        highlight_sql: true
+---
+spring:
+  config:
+    activate:
+      on-profile: local-db
+  jpa:
+    hibernate:
+      ddl-auto: update
+  datasource:
+    url: ${LOCAL_DATASOURCE_URL}
+    username: ${LOCAL_DATASOURCE_USERNAME}
+    password: ${LOCAL_DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local-port
+server:
+  port: 8080
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev-db
+  jpa:
+    hibernate:
+      ddl-auto: update
+  datasource:
+    url: ${DEV_DATASOURCE_URL}
+    username: ${DEV_DATASOURCE_USERNAME}
+    password: ${DEV_DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev-port
+server:
+  port: 8081


### PR DESCRIPTION
## Related issue 🛠
- closed #1

## Work Description 📝

### 공통 응답 클래스 구현
공통 응답 및 공통 예외 응답 클래스를 구현하였습니다. 

### 예외 상수 규정
ErrorCode를 인터페이스로 규정하여, 도메인 별로 이를 상속하는 구조로 설계하여 예외 상수에 대한 가독성을 높이고, 도메인 별 응집성을 높였습니다.
### 전역 예외 핸들러 구현
생성한 ErrorCode 인터페이스를 상속받는 GlobalErrorCode 상수를 구현했습니다. 이는 도메인에 종속되지 않는 전역적으로 발생할 수 있는 예외 에 대한 상수들이며, 이를 전역 예외 핸들러에도 적용시켜 꼼꼼한 예외 처리를 구현했습니다.

