### PR TITLE
[Feat] Swagger 명세 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.7'
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot' version '3.2.4'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'org.sopt'
@@ -39,6 +39,9 @@ dependencies {
 
     //Mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    //Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
 }
 

--- a/src/main/java/org/sopt/idus/global/annotation/CustomExceptionDescription.java
+++ b/src/main/java/org/sopt/idus/global/annotation/CustomExceptionDescription.java
@@ -1,0 +1,15 @@
+package org.sopt.idus.global.annotation;
+
+import org.sopt.idus.global.config.swagger.SwaggerResponseDescription;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomExceptionDescription {
+
+    SwaggerResponseDescription value();
+}

--- a/src/main/java/org/sopt/idus/global/config/swagger/ExampleHolder.java
+++ b/src/main/java/org/sopt/idus/global/config/swagger/ExampleHolder.java
@@ -1,0 +1,14 @@
+package org.sopt.idus.global.config.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/org/sopt/idus/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/org/sopt/idus/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,110 @@
+package org.sopt.idus.global.config.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.sopt.idus.global.annotation.CustomExceptionDescription;
+import org.sopt.idus.global.dto.response.BaseErrorResponse;
+import org.sopt.idus.global.exception.errorcode.ErrorCode;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.groupingBy;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "37기 DIVE SOPT 합동세미나 IDUS API 명세서 ",
+                description = "Springdoc을 이용한 Swagger API 문서입니다.",
+                version = "1.0"
+        )
+)
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components());
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+
+            CustomExceptionDescription customExceptionDescription = handlerMethod.getMethodAnnotation(
+                    CustomExceptionDescription.class);
+
+            // CustomExceptionDescription 어노테이션 단 메소드 적용
+            if (customExceptionDescription != null) {
+                generateErrorCodeResponseExample(operation, customExceptionDescription.value());
+            }
+
+            return operation;
+        };
+    }
+
+    private void generateErrorCodeResponseExample(
+            Operation operation, SwaggerResponseDescription type) {
+
+        ApiResponses responses = operation.getResponses();
+
+        Set<ErrorCode> errorCodeList = type.getErrorCodeList();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+                errorCodeList.stream()
+                        .map(
+                                errorCode -> {
+                                    return ExampleHolder.builder()
+                                            .holder(
+                                                    getSwaggerExample(errorCode))
+                                            .code(errorCode.getHttpStatus())
+                                            .name(errorCode.toString())
+                                            .build();
+                                }
+                        ).collect(groupingBy(ExampleHolder::getCode));
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example getSwaggerExample(ErrorCode errorCode) {
+        BaseErrorResponse errorResponse = BaseErrorResponse.of(errorCode);
+        Example example = new Example();
+        example.description(errorCode.getMessage());
+        example.setValue(errorResponse);
+        return example;
+    }
+
+    private void addExamplesToResponses(
+            ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+                    v.forEach(
+                            exampleHolder -> {
+                                mediaType.addExamples(
+                                        exampleHolder.getName(), exampleHolder.getHolder());
+                            });
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setDescription("");
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(status.toString(), apiResponse);
+                });
+    }
+
+
+}

--- a/src/main/java/org/sopt/idus/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/idus/global/config/swagger/SwaggerResponseDescription.java
@@ -1,0 +1,26 @@
+package org.sopt.idus.global.config.swagger;
+
+import lombok.Getter;
+import org.sopt.idus.global.exception.errorcode.ErrorCode;
+import org.sopt.idus.global.exception.errorcode.GlobalErrorCode;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Getter
+public enum SwaggerResponseDescription {
+    COMMON(new LinkedHashSet<>(Set.of(
+    )))
+
+    ;
+    private final Set<ErrorCode> errorCodeList;
+    SwaggerResponseDescription(Set<ErrorCode> specificErrorCodes) {
+        this.errorCodeList = new LinkedHashSet<>();
+        this.errorCodeList.addAll(specificErrorCodes);
+        this.errorCodeList.addAll(getGlobalErrorCodes());
+    }
+
+    private Set<ErrorCode> getGlobalErrorCodes() {
+        return new LinkedHashSet<>(Set.of(GlobalErrorCode.values()));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: DreamWeaver
+    name: Idus
   profiles:
     group:
       local: local-db, local-port, common
@@ -20,6 +20,7 @@ spring:
         format_sql: true
         show_sql: true
         highlight_sql: true
+
 ---
 spring:
   config:


### PR DESCRIPTION
## Related issue 🛠
- closed #3

## Work Description 📝
- Swagger 관련 초기 세팅을 진행하였습니다.
### 커스텀 어노테이션 작성
Swagger에 예외 명세를 위한 Enum 클래스와 어노테이션을 구현했습니다. 기능 개발을 하실 때 발생할 수 있는 예외들을 ErrorCode로 규정하고, 그 ErrorCode들을 담는 Set을 `SwaggerResponseDescription`에 담아주고, 컨트롤러에 어노테이션을 붙여주시면 됩니다.
만약 예외가 발생하지 않는 기능이라면 `@CustomExceptionDescription(COMMON)`을 붙이면 됩니다. 아무것도 발생하지 않는다면 자동으로 전역 예외들만 명세될 수 있게 구현했습니다.
