### PR TITLE
[Feat] 작품 좋아요 생성 기능 구현

### DIFF
--- a/src/main/java/org/sopt/idus/domain/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/idus/domain/product/controller/ProductController.java
@@ -5,12 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.idus.domain.product.dto.response.ProductResponse;
 import org.sopt.idus.domain.product.service.ProductService;
 import org.sopt.idus.domain.productlike.dto.ProductLikeRequest;
+import org.sopt.idus.domain.review.dto.response.ReviewListResponse;
 import org.sopt.idus.global.annotation.CustomExceptionDescription;
 import org.sopt.idus.global.dto.response.BaseResponse;
 import org.springframework.web.bind.annotation.*;
 
-import static org.sopt.idus.global.config.swagger.SwaggerResponseDescription.CREATE_PRODUCT_LIKE;
-import static org.sopt.idus.global.config.swagger.SwaggerResponseDescription.PRODUCT_DETAIL;
+import static org.sopt.idus.global.config.swagger.SwaggerResponseDescription.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,6 +34,12 @@ public class ProductController {
         return BaseResponse.ok("작품 좋아요 생성 성공");
     }
 
+    @CustomExceptionDescription(GET_REVIEWS)
+    @Operation(summary = "작품 후기 조회", description = "작품의 후기들을 조회합니다.")
+    @GetMapping("{productId}/reviews")
+    public BaseResponse<ReviewListResponse> getReviews(@PathVariable Long productId){
+        return BaseResponse.ok(productService.getReviews(productId),"작품 후기 조회 성공");
+    }
 
 
 }

--- a/src/main/java/org/sopt/idus/domain/product/controller/ProductController.java
+++ b/src/main/java/org/sopt/idus/domain/product/controller/ProductController.java
@@ -4,13 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.sopt.idus.domain.product.dto.response.ProductResponse;
 import org.sopt.idus.domain.product.service.ProductService;
+import org.sopt.idus.domain.productlike.dto.ProductLikeRequest;
 import org.sopt.idus.global.annotation.CustomExceptionDescription;
 import org.sopt.idus.global.dto.response.BaseResponse;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import static org.sopt.idus.global.config.swagger.SwaggerResponseDescription.CREATE_PRODUCT_LIKE;
 import static org.sopt.idus.global.config.swagger.SwaggerResponseDescription.PRODUCT_DETAIL;
 
 @RestController
@@ -26,5 +25,15 @@ public class ProductController {
     public BaseResponse<ProductResponse> getProductDetail(@PathVariable Long productId){
         return BaseResponse.ok(productService.getProductDetail(productId),"작품 조회 성공");
     }
+
+    @CustomExceptionDescription(CREATE_PRODUCT_LIKE)
+    @Operation(summary = "작품 좋아요 생성", description = "작품에 좋아요를 생성합니다.")
+    @PostMapping("{productId}/likes")
+    public BaseResponse<Void> likeProduct(@PathVariable Long productId, @RequestBody ProductLikeRequest request){
+        productService.createProductLike(productId, request.userId());
+        return BaseResponse.ok("작품 좋아요 생성 성공");
+    }
+
+
 
 }

--- a/src/main/java/org/sopt/idus/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/sopt/idus/domain/product/repository/ProductRepository.java
@@ -11,4 +11,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("update Product p set p.likeCount = p.likeCount + 1 where p = :product")
     void increaseLikeCount(Product product);
 
+    @Modifying
+    @Query("update Product p set p.likeCount = p.likeCount - 1 where p = :product")
+    void decreaseLikeCount(Product product);
+
 }

--- a/src/main/java/org/sopt/idus/domain/product/repository/ProductRepository.java
+++ b/src/main/java/org/sopt/idus/domain/product/repository/ProductRepository.java
@@ -2,7 +2,13 @@ package org.sopt.idus.domain.product.repository;
 
 import org.sopt.idus.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    @Modifying
+    @Query("update Product p set p.likeCount = p.likeCount + 1 where p = :product")
+    void increaseLikeCount(Product product);
 
 }

--- a/src/main/java/org/sopt/idus/domain/product/service/ProductService.java
+++ b/src/main/java/org/sopt/idus/domain/product/service/ProductService.java
@@ -9,6 +9,7 @@ import org.sopt.idus.domain.productimage.entity.ProductImage;
 import org.sopt.idus.domain.productimage.repository.ProductImageRepository;
 import org.sopt.idus.domain.productlike.entity.ProductLike;
 import org.sopt.idus.domain.productlike.repository.ProductLikeRepository;
+import org.sopt.idus.domain.review.dto.response.ReviewListResponse;
 import org.sopt.idus.domain.review.entity.Review;
 import org.sopt.idus.domain.review.repository.ReviewRepository;
 import org.sopt.idus.domain.user.entity.User;
@@ -44,7 +45,7 @@ public class ProductService {
         List<Review> reviews = reviewRepository.findAllByProductId(productId);
 
         double averageScore = reviews.stream()
-                .mapToInt(Review::getScore)
+                .mapToDouble(Review::getScore)
                 .average()
                 .orElse(0.0);
 
@@ -76,6 +77,14 @@ public class ProductService {
             return true;
         }
         return false;
+    }
+
+    public ReviewListResponse getReviews(Long productId) {
+        Product product = findById(productId);
+
+        List<Review> reviews = reviewRepository.findAllByProductId(productId);
+
+        return ReviewListResponse.from(reviews);
     }
 
 

--- a/src/main/java/org/sopt/idus/domain/product/service/ProductService.java
+++ b/src/main/java/org/sopt/idus/domain/product/service/ProductService.java
@@ -7,8 +7,13 @@ import org.sopt.idus.domain.product.entity.Product;
 import org.sopt.idus.domain.product.repository.ProductRepository;
 import org.sopt.idus.domain.productimage.entity.ProductImage;
 import org.sopt.idus.domain.productimage.repository.ProductImageRepository;
+import org.sopt.idus.domain.productlike.entity.ProductLike;
+import org.sopt.idus.domain.productlike.repository.ProductLikeRepository;
 import org.sopt.idus.domain.review.entity.Review;
 import org.sopt.idus.domain.review.repository.ReviewRepository;
+import org.sopt.idus.domain.user.entity.User;
+import org.sopt.idus.domain.user.repository.UserRepository;
+import org.sopt.idus.domain.user.service.UserService;
 import org.sopt.idus.global.exception.customexception.CustomException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +33,12 @@ public class ProductService {
 
     private final ReviewRepository reviewRepository;
 
+    private final UserRepository userRepository;
+
+    private final UserService userService;
+
+    private final ProductLikeRepository productLikeRepository;
+
     public ProductResponse getProductDetail(Long productId){
         Product product = findById(productId);
 
@@ -45,6 +56,18 @@ public class ProductService {
 
     private Product findById(Long productId){
         return productRepository.findById(productId).orElseThrow(() -> new CustomException(PRODUCT_NOT_FOUND));
+    }
+
+    @Transactional
+    public void createProductLike(Long productId, Long userId) {
+        Product product = findById(productId);
+        User user = userService.findById(userId);
+
+        ProductLike productLike = ProductLike.create(product, user);
+        productLikeRepository.save(productLike);
+
+        productRepository.increaseLikeCount(product);
+
     }
 
 }

--- a/src/main/java/org/sopt/idus/domain/product/service/ProductService.java
+++ b/src/main/java/org/sopt/idus/domain/product/service/ProductService.java
@@ -12,7 +12,6 @@ import org.sopt.idus.domain.productlike.repository.ProductLikeRepository;
 import org.sopt.idus.domain.review.entity.Review;
 import org.sopt.idus.domain.review.repository.ReviewRepository;
 import org.sopt.idus.domain.user.entity.User;
-import org.sopt.idus.domain.user.repository.UserRepository;
 import org.sopt.idus.domain.user.service.UserService;
 import org.sopt.idus.global.exception.customexception.CustomException;
 import org.springframework.stereotype.Service;
@@ -32,8 +31,6 @@ public class ProductService {
     private final ProductImageRepository productImageRepository;
 
     private final ReviewRepository reviewRepository;
-
-    private final UserRepository userRepository;
 
     private final UserService userService;
 
@@ -63,11 +60,23 @@ public class ProductService {
         Product product = findById(productId);
         User user = userService.findById(userId);
 
+        if (deleteLikeIfPresent(productId, userId, product)) return;
+
         ProductLike productLike = ProductLike.create(product, user);
         productLikeRepository.save(productLike);
 
         productRepository.increaseLikeCount(product);
 
     }
+
+    private boolean deleteLikeIfPresent(Long productId, Long userId, Product product) {
+        if(productLikeRepository.existsByProductIdAndUserId(productId, userId)){
+            productLikeRepository.deleteByProductIdAndUserId(productId, userId);
+            productRepository.decreaseLikeCount(product);
+            return true;
+        }
+        return false;
+    }
+
 
 }

--- a/src/main/java/org/sopt/idus/domain/productlike/entity/ProductLike.java
+++ b/src/main/java/org/sopt/idus/domain/productlike/entity/ProductLike.java
@@ -34,8 +34,12 @@ public class ProductLike {
     private User user;
 
     @Builder
-    public ProductLike(Product product, User user) {
+    private ProductLike(Product product, User user) {
         this.product = product;
         this.user = user;
+    }
+
+    public static ProductLike create(Product product, User user) {
+        return new ProductLike(product, user);
     }
 }

--- a/src/main/java/org/sopt/idus/domain/productlike/repository/ProductLikeRepository.java
+++ b/src/main/java/org/sopt/idus/domain/productlike/repository/ProductLikeRepository.java
@@ -4,4 +4,8 @@ import org.sopt.idus.domain.productlike.entity.ProductLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> {
+
+    boolean existsByProductIdAndUserId(Long productId, Long userId);
+
+    void deleteByProductIdAndUserId(Long productId, Long userId);
 }

--- a/src/main/java/org/sopt/idus/domain/productlike/repository/ProductLikeRepository.java
+++ b/src/main/java/org/sopt/idus/domain/productlike/repository/ProductLikeRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.idus.domain.productlike.repository;
+
+import org.sopt.idus.domain.productlike.entity.ProductLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> {
+}

--- a/src/main/java/org/sopt/idus/domain/review/dto/response/ReviewListResponse.java
+++ b/src/main/java/org/sopt/idus/domain/review/dto/response/ReviewListResponse.java
@@ -1,0 +1,15 @@
+package org.sopt.idus.domain.review.dto.response;
+
+import org.sopt.idus.domain.review.entity.Review;
+
+import java.util.List;
+
+public record ReviewListResponse(
+        List<ReviewResponse> reviewResponses
+) {
+    public static ReviewListResponse from(List<Review> reviews) {
+        return new ReviewListResponse(reviews.stream()
+                .map(ReviewResponse::from)
+                .toList());
+    }
+}

--- a/src/main/java/org/sopt/idus/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/org/sopt/idus/domain/review/dto/response/ReviewResponse.java
@@ -1,15 +1,24 @@
-package org.sopt.idus.domain.review.dto;
+package org.sopt.idus.domain.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.sopt.idus.domain.review.entity.Review;
 import org.sopt.idus.domain.user.entity.User;
 
 import java.time.LocalDate;
 
 public record ReviewResponse(
+        @Schema(description = "리뷰 ID", example = "1")
         Long reviewId,
-        Integer score,
+
+        @Schema(description = "별점", example = "4.0")
+        double score,
+
+        @Schema(description = "내용", example = "좋아요~")
         String content,
+
+        @Schema(description = "리뷰 생성일", example = "2025-11-01")
         LocalDate createdAt,
+
         Reviewer reviewer
 ) {
     public static ReviewResponse from(Review review) {
@@ -23,9 +32,14 @@ public record ReviewResponse(
     }
 
     public record Reviewer(
-            Long id,
-            String nickName,
-            String imageUrl
+            @Schema(description = "유저 ID", example = "1")
+            Long userId,
+
+            @Schema(description = "유저 닉네임", example = "임지성")
+            String nickname,
+
+            @Schema(description = "유저 프로필 이미지")
+            String profileImageUrl
     ) {
         public static Reviewer from(User user) {
             return new Reviewer(

--- a/src/main/java/org/sopt/idus/domain/review/entity/Review.java
+++ b/src/main/java/org/sopt/idus/domain/review/entity/Review.java
@@ -13,21 +13,12 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(
-        name = "review",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uq_review_user_product",
-                        columnNames = {"user_id", "product_id"}
-                )
-        }
-)
 public class Review {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Integer score;
+    private double score;
 
     private String content;
 
@@ -42,7 +33,7 @@ public class Review {
     private User user;
 
     @Builder
-    public Review(Integer score, String content, Product product, User user) {
+    public Review(double score, String content, Product product, User user) {
         this.score = score;
         this.content = content;
         this.product = product;

--- a/src/main/java/org/sopt/idus/domain/user/errorcode/UserErrorCode.java
+++ b/src/main/java/org/sopt/idus/domain/user/errorcode/UserErrorCode.java
@@ -1,0 +1,25 @@
+package org.sopt.idus.domain.user.errorcode;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.idus.global.exception.errorcode.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 사용자입니다.")
+    ;
+
+    private final int httpStatus;
+
+    private final String message;
+
+    @Override
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/idus/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/sopt/idus/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.idus.domain.user.repository;
+
+import org.sopt.idus.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/org/sopt/idus/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/idus/domain/user/service/UserService.java
@@ -1,0 +1,20 @@
+package org.sopt.idus.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.idus.domain.user.entity.User;
+import org.sopt.idus.domain.user.repository.UserRepository;
+import org.sopt.idus.global.exception.customexception.CustomException;
+import org.springframework.stereotype.Service;
+
+import static org.sopt.idus.domain.user.errorcode.UserErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/idus/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/idus/global/config/swagger/SwaggerResponseDescription.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static org.sopt.idus.domain.product.errorcode.ProductErrorCode.PRODUCT_NOT_FOUND;
+import static org.sopt.idus.domain.user.errorcode.UserErrorCode.USER_NOT_FOUND;
 
 @Getter
 public enum SwaggerResponseDescription {
@@ -15,6 +16,10 @@ public enum SwaggerResponseDescription {
     ))),
     PRODUCT_DETAIL(new LinkedHashSet<>(Set.of(
             PRODUCT_NOT_FOUND
+    ))),
+    CREATE_PRODUCT_LIKE(new LinkedHashSet<>(Set.of(
+            PRODUCT_NOT_FOUND,
+            USER_NOT_FOUND
     )))
 
     ;

--- a/src/main/java/org/sopt/idus/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/sopt/idus/global/config/swagger/SwaggerResponseDescription.java
@@ -20,6 +20,9 @@ public enum SwaggerResponseDescription {
     CREATE_PRODUCT_LIKE(new LinkedHashSet<>(Set.of(
             PRODUCT_NOT_FOUND,
             USER_NOT_FOUND
+    ))),
+    GET_REVIEWS(new LinkedHashSet<>(Set.of(
+            PRODUCT_NOT_FOUND
     )))
 
     ;


### PR DESCRIPTION
## Related issue 🛠
- closed #11

## Work Description 📝
### 증분 쿼리 사용
사전에 협의한 대로 좋아요 수를 집계하는 방식이 아닌, Product에 컬럼으로 두기로 했기 때문에, 증분 쿼리를 사용해서 좋아요를 누를 때 +1, 취소할 때 -1 되도록 구현했습니다. 
만약 Product 도메인에 좋아요 수를 증가시키는 로직을 넣게 되면 다음과 같은 흐름으로 동작할 것입니다.
```
Product product = productRepository.findById(id); //SELECT 쿼리 발생
product.increaseLikecount();
productRepository.save(product); // UPDATE 쿼리 발생
```
하지만 증분 쿼리를 사용하면 UPDATE 쿼리 하나로 처리할 수 있고, DB가 쿼리를 직접 수행하기 때문에 원자적인 연산을 해 DB 내부에서 락이 적용되어 좋아요 로직에 치명적인 **동시성 문제를 자연스럽게 해결할 수 있습니다**.
### 생성자 private 보호
기존에 ProductLike 엔티티 내부 생성자는 다음과 같이 구현되어 있었습니다.
```
@Builder
public ProductLike(Product product, User user) {
        this.product = product;
        this.user = user;
    }
```
생성자가 public으로 구현되어 있어 외부에서 생성자를 무분별하게 호출할 수 있기 때문에 생성자를 private으로 막고 정적 팩토리 메서드를 통해 생성할 수 있게 수정했습니다.